### PR TITLE
fix service name error

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -143,6 +143,8 @@ def lambda_handler(event: dict, context=None):
         "logStream": data.get("logStream"),
         "messageType": data.get("messageType"),
         "subscriptionFilters": data.get("subscriptionFilters"),
+        "serviceName": "unknown",
+        "logGroupName": ""
     }
 
     if len(data_tags) > 0:

--- a/handler.py
+++ b/handler.py
@@ -54,6 +54,7 @@ if data_tags_string != "":
             continue
         data_tags[tag_splitted[0]] = tag_splitted[1]
 
+
 # try to get json from message
 def structured_message(message: str):
     try:
@@ -144,7 +145,7 @@ def lambda_handler(event: dict, context=None):
         "messageType": data.get("messageType"),
         "subscriptionFilters": data.get("subscriptionFilters"),
         "serviceName": "unknown",
-        "logGroupName": ""
+        "logGroupName": "",
     }
 
     if len(data_tags) > 0:


### PR DESCRIPTION
we had a discord user reach out on having a traceback, service name error in line 182 here: https://discord.com/channels/1065957163161370664/1123693750430994494/1123693750430994494

This will ensure that `serviceName` and `logGroupName` keys always exist in `aws_fields`, preventing a KeyError from being thrown.