### PR TITLE
fix handler key error

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -86,6 +86,11 @@ def push_events_to_axiom(events: list):
 
 
 def data_from_event(event: dict) -> dict:
+    
+    if "awslogs" not in event or "data" not in event["awslogs"]:
+        logger.warning(f"Unexpected event format: {json.dumps(event)}")
+        return {}
+    
     body = base64.b64decode(event["awslogs"]["data"])
     data = gzip.decompress(body)
     return json.loads(data)
@@ -137,6 +142,8 @@ def lambda_handler(event: dict, context=None):
         raise Exception("AXIOM_DATASET is not set")
 
     data = data_from_event(event)
+    if not data:
+        return
 
     aws_fields = {
         "owner": data.get("owner"),

--- a/handler.py
+++ b/handler.py
@@ -86,11 +86,10 @@ def push_events_to_axiom(events: list):
 
 
 def data_from_event(event: dict) -> dict:
-    
     if "awslogs" not in event or "data" not in event["awslogs"]:
         logger.warning(f"Unexpected event format: {json.dumps(event)}")
         return {}
-    
+
     body = base64.b64decode(event["awslogs"]["data"])
     data = gzip.decompress(body)
     return json.loads(data)


### PR DESCRIPTION
discord user reported a new issue: https://discord.com/channels/1065957163161370664/1123693750430994494/1135751410420559942

```
{
  "errorMessage": "'awslogs'",
  "errorType": "KeyError",
  "stackTrace": [
    "  File \"/var/task/index.py\", line 138, in lambda_handler\n    data = data_from_event(event)\n",
    "  File \"/var/task/index.py\", line 88, in data_from_event\n    body = base64.b64decode(event[\"awslogs\"][\"data\"])\n"
  ]
}
```

this pr check the `data_from_event` function to check if the `awslogs key `is present in the event