### PR TITLE
fix lambda function name being overwritten

### DIFF
--- a/axiom-cloudwatch-lambda-cloudformation-stack.template.yaml
+++ b/axiom-cloudwatch-lambda-cloudformation-stack.template.yaml
@@ -59,7 +59,6 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       Runtime: python3.9
-      FunctionName: axiom-cloudwatch-lambda
       Handler: index.lambda_handler
       Code:
         ZipFile: |


### PR DESCRIPTION
### Description
The lambda function name that is given from the parameters is getting overwritten by the hardcoded name inside the yaml. This becomes an issue once I try to create another lambda. AWS is throwing an error and saying there is already a lambda with that name exists, even if I give a different name.