### PR TITLE
Add CDK support to Axiom cloudwatch template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 /build
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.venv
+*.egg-info
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/Axiom.py
+++ b/Axiom.py
@@ -1,0 +1,248 @@
+from aws_cdk import (
+    aws_iam as iam,
+    aws_lambda as lambda_,
+    aws_logs as logs,
+    aws_s3 as s3,
+    aws_events as events,
+    aws_events_targets as targets,
+    aws_cloudtrail as cloudtrail,
+)
+import aws_cdk as core
+from constructs import Construct
+
+class CloudWatchIngester(Construct):
+
+    def __init__(self, scope: Construct, id: str, axiom_token: str, axiom_url: str, axiom_dataset: str, cloudwatch_log_group_names: list, lambda_function_name: str, data_tags: str, disable_json: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        logs_role = iam.Role(self, "LogsRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
+            ]
+        )
+
+        lambda_function = lambda_.Function(self, "LogsLambda",
+            function_name=lambda_function_name,
+            runtime=lambda_.Runtime.PYTHON_3_9,
+            handler="handler.lambda_handler",
+            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
+            role=logs_role,
+            environment={
+                "AXIOM_TOKEN": axiom_token,
+                "AXIOM_DATASET": axiom_dataset,
+                "AXIOM_URL": axiom_url,
+                "DISABLE_JSON": disable_json,
+                "DATA_TAGS": data_tags
+            }
+        )
+
+        for log_group_name in cloudwatch_log_group_names:
+            logs.CfnSubscriptionFilter(self, f"LGSF{log_group_name}",
+                log_group_name=log_group_name,
+                filter_pattern="",
+                destination_arn=lambda_function.function_arn
+            )
+
+        lambda_.CfnPermission(self, "LogsLambdaWildcardPermission",
+            action="lambda:InvokeFunction",
+            function_name=lambda_function.function_name,
+            principal=f"logs.{core.Aws.REGION}.amazonaws.com",
+            source_account=core.Aws.ACCOUNT_ID,
+            source_arn=f"arn:aws:logs:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:log-group:*"
+        )
+
+        core.CfnOutput(self, "LogsLambdaARN",
+            description="The ARN of the created Ingester Lambda",
+            value=lambda_function.function_arn,
+            export_name=f"{id}-LogsLambdaARN"
+        )
+
+class CloudWatchBackfiller(Construct):
+
+    def __init__(self, scope: Construct, id: str, lambda_function_name: str, axiom_cloudwatch_lambda_ingester_arn: str, cloudwatch_log_groups_prefix: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        backfiller_role = iam.Role(self, "BackfillerRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
+            ]
+        )
+
+        backfiller_policy = iam.Policy(self, "BackfillerPolicy",
+            policy_name="axiom-cloudwatch-backfiller-lambda-policy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "logs:DeleteSubscriptionFilter",
+                        "logs:PutSubscriptionFilter",
+                        "logs:DescribeLogGroups",
+                        "lambda:AddPermission",
+                        "lambda:RemovePermission"
+                    ],
+                    resources=["*"],
+                    effect=iam.Effect.ALLOW
+                )
+            ]
+        )
+        backfiller_policy.attach_to_role(backfiller_role)
+
+        backfiller_lambda = lambda_.Function(self, "BackfillerLambda",
+            function_name=lambda_function_name,
+            runtime=lambda_.Runtime.PYTHON_3_9,
+            handler="backfill.lambda_handler",
+            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
+            role=backfiller_role,
+            timeout=core.Duration.minutes(5),
+            environment={
+                "AXIOM_CLOUDWATCH_LAMBDA_INGESTER_ARN": axiom_cloudwatch_lambda_ingester_arn,
+                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix
+            }
+        )
+
+        core.CfnOutput(self, "BackfillerLambdaARN",
+            description="The ARN of the created Backfiller Lambda",
+            value=backfiller_lambda.function_arn,
+            export_name=f"{id}-BackfillerLambdaARN"
+        )
+
+class CloudWatchSubscriber(Construct):
+
+    def __init__(self, scope: Construct, id: str, lambda_function_name: str, axiom_cloudwatch_lambda_ingester_arn: str, cloudwatch_log_groups_prefix: str, axiom_lambda_log_retention: int, enable_cloudtrail: bool, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        should_enable_cloudtrail = enable_cloudtrail
+
+        if should_enable_cloudtrail:
+            s3_bucket = s3.Bucket(self, "AxiomCloudWatchLogsSubscriberS3Bucket",
+                bucket_name=f"{core.Aws.STACK_NAME}-cloudtrail",
+                access_control=s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL
+            )
+
+            s3_bucket.add_to_resource_policy(iam.PolicyStatement(
+                actions=["s3:GetBucketAcl"],
+                principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
+                resources=[s3_bucket.bucket_arn],
+                effect=iam.Effect.ALLOW
+            ))
+
+            s3_bucket.add_to_resource_policy(iam.PolicyStatement(
+                actions=["s3:PutObject"],
+                principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
+                resources=[f"{s3_bucket.bucket_arn}/AWSLogs/{core.Aws.ACCOUNT_ID}/*"],
+                effect=iam.Effect.ALLOW,
+                conditions={"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
+            ))
+
+            cloudtrail.Trail(self, "AxiomLogsSubscriberCloudTrail",
+                bucket=s3_bucket,
+                trail_name=f"{core.Aws.STACK_NAME}-{core.Aws.ACCOUNT_ID}",
+                is_multi_region_trail=True,
+                include_global_service_events=True,
+                enable_file_validation=False
+            )
+
+        subscriber_role = iam.Role(self, "AxiomCloudWatchLogsSubscriberRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
+            ]
+        )
+
+        subscriber_policy = iam.Policy(self, "AxiomCloudWatchLogsSubscriberPolicy",
+            policy_name="cloudwatch-subscriber-axiom-policy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "logs:DeleteSubscriptionFilter",
+                        "logs:PutSubscriptionFilter",
+                        "logs:DescribeLogGroups",
+                        "lambda:AddPermission",
+                        "lambda:RemovePermission",
+                        "lambda:InvokeFunction",
+                        "lambda:GetFunction",
+                        "logs:DescribeLogStreams",
+                        "logs:DescribeSubscriptionFilters",
+                        "logs:FilterLogEvents",
+                        "logs:GetLogEvents"
+                    ],
+                    resources=["*"],
+                    effect=iam.Effect.ALLOW
+                )
+            ]
+        )
+        subscriber_policy.attach_to_role(subscriber_role)
+        
+
+        subscriber_lambda = lambda_.Function(self, "AxiomCloudWatchLogsSubscriber",
+            function_name=lambda_function_name,
+            runtime=lambda_.Runtime.PYTHON_3_9,
+            handler="logs_subscriber.lambda_handler",
+            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
+            role=subscriber_role,
+            environment={
+                "AXIOM_CLOUDWATCH_LAMBDA_INGESTER_ARN": axiom_cloudwatch_lambda_ingester_arn,
+                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix
+            },
+            log_retention=logs.RetentionDays.ONE_DAY if axiom_lambda_log_retention == 1 else axiom_lambda_log_retention
+        )
+
+        event_rule = events.Rule(self, "AxiomLogsSubscriberEventRule",
+            description="Axiom log group auto subscription event rule.",
+            event_pattern={
+                "source": ["aws.logs"],
+                "detail": {
+                    "eventSource": ["logs.amazonaws.com"],
+                    "eventName": ["CreateLogGroup"]
+                }
+            }
+        )
+        event_rule.add_target(targets.LambdaFunction(subscriber_lambda))
+
+        lambda_.CfnPermission(self, "AxiomCloudWatchLogsSubscriberPermission",
+            action="lambda:InvokeFunction",
+            function_name=subscriber_lambda.function_arn,
+            principal="events.amazonaws.com",
+            source_account=core.Aws.ACCOUNT_ID,
+            source_arn=event_rule.rule_arn
+        )
+
+        logs.LogGroup(self, "AxiomCloudWatchLogsSubscriberLogGroup",
+            log_group_name=f"/aws/lambda/{lambda_function_name}",
+            retention=logs.RetentionDays.ONE_DAY if axiom_lambda_log_retention == 1 else axiom_lambda_log_retention
+        )
+
+        core.CfnOutput(self, "SubscriberLambdaARN",
+            description="The ARN of the created Subscriber Lambda",
+            value=subscriber_lambda.function_arn,
+            export_name=f"{id}-SubscriberLambdaARN"
+        )
+
+class AxiomStack(core.Stack):
+
+    def __init__(self, scope: Construct, id: str, axiom_token: str, axiom_url: str, axiom_dataset: str, cloudwatch_log_group_names: list, ingester_lambda_function_name: str, backfiller_lambda_function_name: str, subscriber_lambda_function_name: str, data_tags: str, disable_json: str, cloudwatch_log_groups_prefix: str, axiom_lambda_log_retention: int, enable_cloudtrail: bool, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+        ingester = CloudWatchIngester(self, "CloudWatchIngester",
+            axiom_token=axiom_token,
+            axiom_url=axiom_url,
+            axiom_dataset=axiom_dataset,
+            cloudwatch_log_group_names=cloudwatch_log_group_names,
+            lambda_function_name=ingester_lambda_function_name,
+            data_tags=data_tags,
+            disable_json=disable_json
+        )
+
+        backfiller = CloudWatchBackfiller(self, "CloudWatchBackfiller",
+            lambda_function_name=backfiller_lambda_function_name,
+            axiom_cloudwatch_lambda_ingester_arn=core.Fn.import_value("CloudWatchIngester-LogsLambdaARN"),
+            cloudwatch_log_groups_prefix=cloudwatch_log_groups_prefix
+        )
+
+        subscriber = CloudWatchSubscriber(self, "CloudWatchSubscriber",
+            lambda_function_name=subscriber_lambda_function_name,
+            axiom_cloudwatch_lambda_ingester_arn=core.Fn.import_value("CloudWatchIngester-LogsLambdaARN"),
+            cloudwatch_log_groups_prefix=cloudwatch_log_groups_prefix,
+            axiom_lambda_log_retention=axiom_lambda_log_retention,
+            enable_cloudtrail=enable_cloudtrail
+        )

--- a/Axiom.py
+++ b/Axiom.py
@@ -138,23 +138,6 @@ class CloudWatchBackfiller(Construct):
             export_name=f"{id}-BackfillerLambdaARN",
         )
 
-        backfiller_lambda_provider = cr.Provider(
-            self,
-            "BackfillerLambdaProvider",
-            on_event_handler=backfiller_lambda
-        )
-
-        custom_resource = core.CustomResource(
-            self,
-            "BackfillerTrigger",
-            service_token=backfiller_lambda_provider.service_token,
-            properties={
-                "DummyProperty": "TriggerLambda"
-            }
-        )
-
-        custom_resource.node.add_dependency(backfiller_lambda)
-
 
 class CloudWatchSubscriber(Construct):
     def __init__(

--- a/Axiom.py
+++ b/Axiom.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     aws_events as events,
     aws_events_targets as targets,
     aws_cloudtrail as cloudtrail,
+    custom_resources as cr
 )
 import aws_cdk as core
 from constructs import Construct
@@ -136,6 +137,23 @@ class CloudWatchBackfiller(Construct):
             value=backfiller_lambda.function_arn,
             export_name=f"{id}-BackfillerLambdaARN",
         )
+
+        backfiller_lambda_provider = cr.Provider(
+            self,
+            "BackfillerLambdaProvider",
+            on_event_handler=backfiller_lambda
+        )
+
+        custom_resource = core.CustomResource(
+            self,
+            "BackfillerTrigger",
+            service_token=backfiller_lambda_provider.service_token,
+            properties={
+                "DummyProperty": "TriggerLambda"
+            }
+        )
+
+        custom_resource.node.add_dependency(backfiller_lambda)
 
 
 class CloudWatchSubscriber(Construct):

--- a/Axiom.py
+++ b/Axiom.py
@@ -32,7 +32,7 @@ class CloudWatchIngester(Construct):
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="handler.lambda_handler",
             code=lambda_.Code.from_asset(
-                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+                "./", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
             ),
             environment={
                 "AXIOM_TOKEN": axiom_token,
@@ -119,7 +119,7 @@ class CloudWatchBackfiller(Construct):
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="backfill.lambda_handler",
             code=lambda_.Code.from_asset(
-                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+                "./", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
             ),
             role=backfiller_role,
             timeout=core.Duration.minutes(5),
@@ -236,7 +236,7 @@ class CloudWatchSubscriber(Construct):
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="logs_subscriber.lambda_handler",
             code=lambda_.Code.from_asset(
-                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+                "./", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
             ),
             role=subscriber_role,
             environment={

--- a/Axiom.py
+++ b/Axiom.py
@@ -10,67 +10,92 @@ from aws_cdk import (
 import aws_cdk as core
 from constructs import Construct
 
-class CloudWatchIngester(Construct):
 
-    def __init__(self, scope: Construct, id: str, axiom_token: str, axiom_url: str, axiom_dataset: str, cloudwatch_log_group_names: list, lambda_function_name: str, data_tags: str, disable_json: str, **kwargs) -> None:
+class CloudWatchIngester(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        axiom_token: str,
+        axiom_url: str,
+        axiom_dataset: str,
+        cloudwatch_log_group_names: list,
+        data_tags: str,
+        disable_json: str,
+        **kwargs,
+    ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        logs_role = iam.Role(self, "LogsRole",
-            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
-            ]
-        )
-
-        lambda_function = lambda_.Function(self, "LogsLambda",
-            function_name=lambda_function_name,
+        lambda_function = lambda_.Function(
+            self,
+            "LogsLambda",
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="handler.lambda_handler",
-            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
-            role=logs_role,
+            code=lambda_.Code.from_asset(
+                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+            ),
             environment={
                 "AXIOM_TOKEN": axiom_token,
                 "AXIOM_DATASET": axiom_dataset,
                 "AXIOM_URL": axiom_url,
                 "DISABLE_JSON": disable_json,
-                "DATA_TAGS": data_tags
-            }
+                "DATA_TAGS": data_tags,
+            },
         )
 
         for log_group_name in cloudwatch_log_group_names:
-            logs.CfnSubscriptionFilter(self, f"LGSF{log_group_name}",
+            logs.CfnSubscriptionFilter(
+                self,
+                f"LGSF{log_group_name}",
                 log_group_name=log_group_name,
-                filter_pattern="",
-                destination_arn=lambda_function.function_arn
+                destination_arn=lambda_function.function_arn,
             )
 
-        lambda_.CfnPermission(self, "LogsLambdaWildcardPermission",
+        lambda_.CfnPermission(
+            self,
+            "LogsLambdaWildcardPermission",
             action="lambda:InvokeFunction",
             function_name=lambda_function.function_name,
             principal=f"logs.{core.Aws.REGION}.amazonaws.com",
             source_account=core.Aws.ACCOUNT_ID,
-            source_arn=f"arn:aws:logs:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:log-group:*"
+            source_arn=f"arn:aws:logs:{core.Aws.REGION}:{core.Aws.ACCOUNT_ID}:log-group:*",
         )
 
-        core.CfnOutput(self, "LogsLambdaARN",
+        core.CfnOutput(
+            self,
+            "LogsLambdaARN",
             description="The ARN of the created Ingester Lambda",
             value=lambda_function.function_arn,
-            export_name=f"{id}-LogsLambdaARN"
+            export_name=f"{id}-LogsLambdaARN",
         )
+        self.arn = lambda_function.function_arn
+
 
 class CloudWatchBackfiller(Construct):
-
-    def __init__(self, scope: Construct, id: str, lambda_function_name: str, axiom_cloudwatch_lambda_ingester_arn: str, cloudwatch_log_groups_prefix: str, **kwargs) -> None:
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        axiom_cloudwatch_lambda_ingester_arn: str,
+        cloudwatch_log_groups_prefix: str,
+        **kwargs,
+    ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        backfiller_role = iam.Role(self, "BackfillerRole",
+        backfiller_role = iam.Role(
+            self,
+            "BackfillerRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
-            ]
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                )
+            ],
         )
 
-        backfiller_policy = iam.Policy(self, "BackfillerPolicy",
+        backfiller_policy = iam.Policy(
+            self,
+            "BackfillerPolicy",
             policy_name="axiom-cloudwatch-backfiller-lambda-policy",
             statements=[
                 iam.PolicyStatement(
@@ -79,78 +104,109 @@ class CloudWatchBackfiller(Construct):
                         "logs:PutSubscriptionFilter",
                         "logs:DescribeLogGroups",
                         "lambda:AddPermission",
-                        "lambda:RemovePermission"
+                        "lambda:RemovePermission",
                     ],
                     resources=["*"],
-                    effect=iam.Effect.ALLOW
+                    effect=iam.Effect.ALLOW,
                 )
-            ]
+            ],
         )
         backfiller_policy.attach_to_role(backfiller_role)
 
-        backfiller_lambda = lambda_.Function(self, "BackfillerLambda",
-            function_name=lambda_function_name,
+        backfiller_lambda = lambda_.Function(
+            self,
+            "BackfillerLambda",
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="backfill.lambda_handler",
-            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
+            code=lambda_.Code.from_asset(
+                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+            ),
             role=backfiller_role,
             timeout=core.Duration.minutes(5),
             environment={
                 "AXIOM_CLOUDWATCH_LAMBDA_INGESTER_ARN": axiom_cloudwatch_lambda_ingester_arn,
-                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix
-            }
+                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix,
+            },
         )
 
-        core.CfnOutput(self, "BackfillerLambdaARN",
+        core.CfnOutput(
+            self,
+            "BackfillerLambdaARN",
             description="The ARN of the created Backfiller Lambda",
             value=backfiller_lambda.function_arn,
-            export_name=f"{id}-BackfillerLambdaARN"
+            export_name=f"{id}-BackfillerLambdaARN",
         )
 
-class CloudWatchSubscriber(Construct):
 
-    def __init__(self, scope: Construct, id: str, lambda_function_name: str, axiom_cloudwatch_lambda_ingester_arn: str, cloudwatch_log_groups_prefix: str, axiom_lambda_log_retention: int, enable_cloudtrail: bool, **kwargs) -> None:
+class CloudWatchSubscriber(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        axiom_cloudwatch_lambda_ingester_arn: str,
+        cloudwatch_log_groups_prefix: str,
+        enable_cloudtrail: bool = False,
+        **kwargs,
+    ) -> None:
         super().__init__(scope, id, **kwargs)
 
         should_enable_cloudtrail = enable_cloudtrail
 
         if should_enable_cloudtrail:
-            s3_bucket = s3.Bucket(self, "AxiomCloudWatchLogsSubscriberS3Bucket",
+            s3_bucket = s3.Bucket(
+                self,
+                "AxiomCloudWatchLogsSubscriberS3Bucket",
                 bucket_name=f"{core.Aws.STACK_NAME}-cloudtrail",
-                access_control=s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL
+                access_control=s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
             )
 
-            s3_bucket.add_to_resource_policy(iam.PolicyStatement(
-                actions=["s3:GetBucketAcl"],
-                principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
-                resources=[s3_bucket.bucket_arn],
-                effect=iam.Effect.ALLOW
-            ))
+            s3_bucket.add_to_resource_policy(
+                iam.PolicyStatement(
+                    actions=["s3:GetBucketAcl"],
+                    principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
+                    resources=[s3_bucket.bucket_arn],
+                    effect=iam.Effect.ALLOW,
+                )
+            )
 
-            s3_bucket.add_to_resource_policy(iam.PolicyStatement(
-                actions=["s3:PutObject"],
-                principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
-                resources=[f"{s3_bucket.bucket_arn}/AWSLogs/{core.Aws.ACCOUNT_ID}/*"],
-                effect=iam.Effect.ALLOW,
-                conditions={"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
-            ))
+            s3_bucket.add_to_resource_policy(
+                iam.PolicyStatement(
+                    actions=["s3:PutObject"],
+                    principals=[iam.ServicePrincipal("cloudtrail.amazonaws.com")],
+                    resources=[
+                        f"{s3_bucket.bucket_arn}/AWSLogs/{core.Aws.ACCOUNT_ID}/*"
+                    ],
+                    effect=iam.Effect.ALLOW,
+                    conditions={
+                        "StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}
+                    },
+                )
+            )
 
-            cloudtrail.Trail(self, "AxiomLogsSubscriberCloudTrail",
+            cloudtrail.Trail(
+                self,
+                "AxiomLogsSubscriberCloudTrail",
                 bucket=s3_bucket,
                 trail_name=f"{core.Aws.STACK_NAME}-{core.Aws.ACCOUNT_ID}",
                 is_multi_region_trail=True,
                 include_global_service_events=True,
-                enable_file_validation=False
+                enable_file_validation=False,
             )
 
-        subscriber_role = iam.Role(self, "AxiomCloudWatchLogsSubscriberRole",
+        subscriber_role = iam.Role(
+            self,
+            "AxiomCloudWatchLogsSubscriberRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole")
-            ]
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                )
+            ],
         )
 
-        subscriber_policy = iam.Policy(self, "AxiomCloudWatchLogsSubscriberPolicy",
+        subscriber_policy = iam.Policy(
+            self,
+            "AxiomCloudWatchLogsSubscriberPolicy",
             policy_name="cloudwatch-subscriber-axiom-policy",
             statements=[
                 iam.PolicyStatement(
@@ -165,84 +221,101 @@ class CloudWatchSubscriber(Construct):
                         "logs:DescribeLogStreams",
                         "logs:DescribeSubscriptionFilters",
                         "logs:FilterLogEvents",
-                        "logs:GetLogEvents"
+                        "logs:GetLogEvents",
                     ],
                     resources=["*"],
-                    effect=iam.Effect.ALLOW
+                    effect=iam.Effect.ALLOW,
                 )
-            ]
+            ],
         )
         subscriber_policy.attach_to_role(subscriber_role)
-        
 
-        subscriber_lambda = lambda_.Function(self, "AxiomCloudWatchLogsSubscriber",
-            function_name=lambda_function_name,
+        subscriber_lambda = lambda_.Function(
+            self,
+            "AxiomCloudWatchLogsSubscriber",
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="logs_subscriber.lambda_handler",
-            code=lambda_.Code.from_asset("../",exclude=["cdk","*.yaml","cdk.out",".venv"]),
+            code=lambda_.Code.from_asset(
+                "../", exclude=["cdk", "*.yaml", "cdk.out", ".venv"]
+            ),
             role=subscriber_role,
             environment={
                 "AXIOM_CLOUDWATCH_LAMBDA_INGESTER_ARN": axiom_cloudwatch_lambda_ingester_arn,
-                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix
+                "LOG_GROUP_PREFIX": cloudwatch_log_groups_prefix,
             },
-            log_retention=logs.RetentionDays.ONE_DAY if axiom_lambda_log_retention == 1 else axiom_lambda_log_retention
         )
 
-        event_rule = events.Rule(self, "AxiomLogsSubscriberEventRule",
+        event_rule = events.Rule(
+            self,
+            "AxiomLogsSubscriberEventRule",
             description="Axiom log group auto subscription event rule.",
             event_pattern={
                 "source": ["aws.logs"],
                 "detail": {
                     "eventSource": ["logs.amazonaws.com"],
-                    "eventName": ["CreateLogGroup"]
-                }
-            }
+                    "eventName": ["CreateLogGroup"],
+                },
+            },
         )
         event_rule.add_target(targets.LambdaFunction(subscriber_lambda))
 
-        lambda_.CfnPermission(self, "AxiomCloudWatchLogsSubscriberPermission",
+        lambda_.CfnPermission(
+            self,
+            "AxiomCloudWatchLogsSubscriberPermission",
             action="lambda:InvokeFunction",
             function_name=subscriber_lambda.function_arn,
             principal="events.amazonaws.com",
             source_account=core.Aws.ACCOUNT_ID,
-            source_arn=event_rule.rule_arn
+            source_arn=event_rule.rule_arn,
         )
 
-        logs.LogGroup(self, "AxiomCloudWatchLogsSubscriberLogGroup",
-            log_group_name=f"/aws/lambda/{lambda_function_name}",
-            retention=logs.RetentionDays.ONE_DAY if axiom_lambda_log_retention == 1 else axiom_lambda_log_retention
-        )
-
-        core.CfnOutput(self, "SubscriberLambdaARN",
+        core.CfnOutput(
+            self,
+            "SubscriberLambdaARN",
             description="The ARN of the created Subscriber Lambda",
             value=subscriber_lambda.function_arn,
-            export_name=f"{id}-SubscriberLambdaARN"
+            export_name=f"{id}-SubscriberLambdaARN",
         )
 
-class AxiomStack(core.Stack):
 
-    def __init__(self, scope: Construct, id: str, axiom_token: str, axiom_url: str, axiom_dataset: str, cloudwatch_log_group_names: list, ingester_lambda_function_name: str, backfiller_lambda_function_name: str, subscriber_lambda_function_name: str, data_tags: str, disable_json: str, cloudwatch_log_groups_prefix: str, axiom_lambda_log_retention: int, enable_cloudtrail: bool, **kwargs) -> None:
+class AxiomStack(core.Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        axiom_token: str,
+        axiom_url: str,
+        axiom_dataset: str,
+        cloudwatch_log_group_names: list,
+        data_tags: str,
+        disable_json: str,
+        cloudwatch_log_groups_prefix: str,
+        enable_cloudtrail: bool,
+        **kwargs,
+    ) -> None:
         super().__init__(scope, id, **kwargs)
-        ingester = CloudWatchIngester(self, "CloudWatchIngester",
+        ingester = CloudWatchIngester(
+            self,
+            "CloudWatchIngester",
             axiom_token=axiom_token,
             axiom_url=axiom_url,
             axiom_dataset=axiom_dataset,
             cloudwatch_log_group_names=cloudwatch_log_group_names,
-            lambda_function_name=ingester_lambda_function_name,
             data_tags=data_tags,
-            disable_json=disable_json
+            disable_json=disable_json,
         )
 
-        backfiller = CloudWatchBackfiller(self, "CloudWatchBackfiller",
-            lambda_function_name=backfiller_lambda_function_name,
-            axiom_cloudwatch_lambda_ingester_arn=core.Fn.import_value("CloudWatchIngester-LogsLambdaARN"),
-            cloudwatch_log_groups_prefix=cloudwatch_log_groups_prefix
-        )
-
-        subscriber = CloudWatchSubscriber(self, "CloudWatchSubscriber",
-            lambda_function_name=subscriber_lambda_function_name,
-            axiom_cloudwatch_lambda_ingester_arn=core.Fn.import_value("CloudWatchIngester-LogsLambdaARN"),
+        backfiller = CloudWatchBackfiller(
+            self,
+            "CloudWatchBackfiller",
+            axiom_cloudwatch_lambda_ingester_arn=ingester.arn,
             cloudwatch_log_groups_prefix=cloudwatch_log_groups_prefix,
-            axiom_lambda_log_retention=axiom_lambda_log_retention,
-            enable_cloudtrail=enable_cloudtrail
+        )
+
+        subscriber = CloudWatchSubscriber(
+            self,
+            "CloudWatchSubscriber",
+            axiom_cloudwatch_lambda_ingester_arn=ingester.arn,
+            cloudwatch_log_groups_prefix=cloudwatch_log_groups_prefix,
+            enable_cloudtrail=enable_cloudtrail,
         )

--- a/app.py
+++ b/app.py
@@ -25,14 +25,10 @@ AxiomStack(app, "AxiomStack",
     axiom_token=os.environ.get("AXIOM_KEY"),  # Axiom API token for authentication
     axiom_url="https://api.axiom.co",  # URL to Axiom API
     axiom_dataset=dataset,  # Dataset name in Axiom
-    cloudwatch_log_group_names=[""],  # Names of CloudWatch log groups to ingest
-    ingester_lambda_function_name="cloudwatch-ingester-axiom",  # Name of the Lambda function for ingesting logs
-    backfiller_lambda_function_name="cloudwatch-backfiller-axiom",  # Name of the Lambda function for backfilling logs
-    subscriber_lambda_function_name="cloudwatch-subscriber-axiom",  # Name of the Lambda function for subscribing to log events
+    cloudwatch_log_group_names=[],  # Names of CloudWatch log groups to ingest
     data_tags="",  # Tags to add to the data
     disable_json="false",  # Whether to disable JSON parsing
     cloudwatch_log_groups_prefix="",  # Prefix for CloudWatch log groups
-    axiom_lambda_log_retention=1,  # Log retention period for Lambda functions in days
     enable_cloudtrail=False,  # Whether to enable CloudTrail logs ingestion
     env=cdk.Environment(account=account, region=region)  # Environment configuration for the CDK app
 )

--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+# Import necessary libraries
+import os
+import aws_cdk as cdk
+
+# Import the AxiomStack class from the Axiom module
+from Axiom import AxiomStack
+
+# Initialize the CDK application
+app = cdk.App()
+
+# Check if the AXIOM_KEY environment variable is set, raise an exception if not
+if os.environ.get("AXIOM_KEY") is None:
+    raise Exception("AXIOM_KEY environment variable is not set")
+
+# Define AWS account and region where the stack will be deployed
+account = "9999999"
+region = "us-west-1"
+# Create a dataset name using the account number
+dataset = "aws-" + account
+
+# Instantiate the AxiomStack with necessary parameters
+AxiomStack(app, "AxiomStack",
+    axiom_token=os.environ.get("AXIOM_KEY"),  # Axiom API token for authentication
+    axiom_url="https://api.axiom.co",  # URL to Axiom API
+    axiom_dataset=dataset,  # Dataset name in Axiom
+    cloudwatch_log_group_names=[""],  # Names of CloudWatch log groups to ingest
+    ingester_lambda_function_name="cloudwatch-ingester-axiom",  # Name of the Lambda function for ingesting logs
+    backfiller_lambda_function_name="cloudwatch-backfiller-axiom",  # Name of the Lambda function for backfilling logs
+    subscriber_lambda_function_name="cloudwatch-subscriber-axiom",  # Name of the Lambda function for subscribing to log events
+    data_tags="",  # Tags to add to the data
+    disable_json="false",  # Whether to disable JSON parsing
+    cloudwatch_log_groups_prefix="",  # Prefix for CloudWatch log groups
+    axiom_lambda_log_retention=1,  # Log retention period for Lambda functions in days
+    enable_cloudtrail=False,  # Whether to enable CloudTrail logs ingestion
+    env=cdk.Environment(account=account, region=region)  # Environment configuration for the CDK app
+)
+
+# Synthesize the CDK app, which prepares it for deployment
+app.synth()

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,71 @@
+{
+  "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "**/__pycache__",
+      "tests"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource": true,
+    "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+    "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
+    "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
+    "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
+    "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+    "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
+    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false,
+    "@aws-cdk/aws-stepfunctions-tasks:ecsReduceRunTaskPermissions": true
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib==2.149.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
Add CloudWatch Lambda constructs for Axiom ingestion, backfilling, and subscription

- Updated .gitignore to include common ignores such as *.swp, package-lock.json, __pycache__, .pytest_cache, .venv, *.egg-info, .cdk.staging, and cdk.out.
- Created Axiom.py to define three CDK constructs:
  - CloudWatchIngester: Manages the ingestion of CloudWatch logs to Axiom with parameters for axiom_token, axiom_url, axiom_dataset, cloudwatch_log_group_names, data_tags, and disable_json.
  - CloudWatchBackfiller: Handles backfilling of CloudWatch logs with parameters for axiom_cloudwatch_lambda_ingester_arn and cloudwatch_log_groups_prefix.
  - CloudWatchSubscriber: Automatically subscribes new CloudWatch log groups to Axiom with parameters for axiom_cloudwatch_lambda_ingester_arn, cloudwatch_log_groups_prefix, and enable_cloudtrail.
- Added app.py to initialize the CDK app and deploy the AxiomStack with environment variables and parameters.
- Updated backfill.py to replace cfnresponse with custom send_response function for handling CloudFormation responses.
- Created cdk.json with CDK app configurations and context settings.
- Added requirements.txt to specify required dependencies for the CDK app.