### PR TITLE
Create permission statement for each log group

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,4 @@ flake8 = "*"
 mypy = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -67,6 +67,6 @@ Resources:
           AXIOM_URL: !Ref "AxiomURL"
           DATA_TAGS: !Ref DataTags
 Outputs:
-  ForwarderARN:
+  ForwarderLambdaARN:
     Description: The ARN of the created Forwarder Lambda
     Value: !GetAtt ForwarderLambda.Arn

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -18,7 +18,7 @@ Parameters:
     AllowedPattern: ".+" # required
   DataTags:
     Type: String
-    Description: Tags to be included with the data ingested into Axiom, e.g., <key1>=<value1>,<key2>=<value2>.
+    Description: Tags to be included with the data ingested into Axiom, e.g., <Key1>=<value1>,<Key2>=<value2>.
 Resources:
   ForwarderLogGroup:
     Type: "AWS::Logs::LogGroup"
@@ -26,8 +26,10 @@ Resources:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
-        - Key: "Role"
-          Value: "AxiomCloudWatchForwarder"
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Platform"
+          Value: "Axiom"
   ForwarderRole:
     Type: AWS::IAM::Role
     Properties:
@@ -41,6 +43,13 @@ Resources:
                 - lambda.amazonaws.com
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Role"
+          Value: "AxiomCloudWatchForwarder"
+        - Key: "Platform"
+          Value: "Axiom"
   ForwarderLambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -56,6 +65,13 @@ Resources:
         - Arn
       LoggingConfig:
         LogGroup: !Ref ForwarderLogGroup
+      Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Role"
+          Value: "AxiomCloudWatchForwarder"
+        - Key: "Platform"
+          Value: "Axiom"
       Environment:
         Variables:
           AXIOM_TOKEN: !Ref "AxiomToken"

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -25,6 +25,7 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
+      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -19,13 +19,15 @@ Parameters:
   DataTags:
     Type: String
     Description: Tags to be included with the data ingested into Axiom, e.g., <key1>=<value1>,<key2>=<value2>.
+  ForwarderLambdaName:
+    Type: String
+    Description: The name of the Forwarder Lambda function.
+    Default: "forwarder"
 Resources:
   ForwarderLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub
-        - "/aws/axiom/forwarder/${LambdaFunctionName}"
-        - LambdaFunctionName: !Ref ForwarderLambda
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}-${ForwarderLambdaName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"
@@ -46,7 +48,7 @@ Resources:
   ForwarderLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Join ["-", ["forwarder", !Ref AWS::StackName]]
+      FunctionName: !Join ["-", [!Ref ForwarderLambdaName, !Ref AWS::StackName]]
       Runtime: python3.9
       Handler: index.lambda_handler
       Code:

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -22,10 +22,10 @@ Parameters:
 Resources:
   ForwarderLogGroup:
     Type: "AWS::Logs::LogGroup"
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
-      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -19,15 +19,11 @@ Parameters:
   DataTags:
     Type: String
     Description: Tags to be included with the data ingested into Axiom, e.g., <key1>=<value1>,<key2>=<value2>.
-  ForwarderLambdaName:
-    Type: String
-    Description: The name of the Forwarder Lambda function.
-    Default: "forwarder"
 Resources:
   ForwarderLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}-${ForwarderLambdaName}"
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"
@@ -48,7 +44,7 @@ Resources:
   ForwarderLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Join ["-", [!Ref ForwarderLambdaName, !Ref AWS::StackName]]
+      FunctionName: !Ref AWS::StackName
       Runtime: python3.9
       Handler: index.lambda_handler
       Code:

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -6,7 +6,7 @@ Metadata:
           default: "Forwarder lambda"
         Parameters:
           - AxiomCloudWatchForwarderLambdaARN
-      - Label: 
+      - Label:
           default: "Which log groups to subscribe to?"
         Parameters:
           - CloudWatchLogGroupsNames
@@ -14,6 +14,10 @@ Metadata:
           - CloudWatchLogGroupsPattern
 
 Parameters:
+  LambdaFunctionName:
+    Type: String
+    Description: The name of the Subscriber Lambda function.
+    Default: "subscriber"
   AxiomCloudWatchForwarderLambdaARN:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to ship logs to Axiom.
@@ -43,16 +47,14 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
             Effect: Allow
-            Resource: '*'
+            Resource: "*"
       PolicyName: axiom-cloudwatch-subscriber-lambda-policy
       Roles:
-        - !Ref 'SubscriberRole'
+        - !Ref "SubscriberRole"
   SubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub
-        - "/aws/axiom/forwarder/${LambdaFunctionName}"
-        - LambdaFunctionName: !Ref SubscriberLambda
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}}-${LambdaFunctionName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"
@@ -63,17 +65,17 @@ Resources:
       AssumeRolePolicyDocument:
         Statement:
           - Action:
-              - 'sts:AssumeRole'
+              - "sts:AssumeRole"
             Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   SubscriberLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${AWS::StackName}-subscriber"
+      FunctionName: !Sub "${AWS::StackName}-${LambdaFunctionName}"
       Runtime: python3.9
       Handler: index.lambda_handler
       Timeout: 300
@@ -88,10 +90,10 @@ Resources:
         LogGroup: !Ref SubscriberLogGroup
       Environment:
         Variables:
-          AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref 'AxiomCloudWatchForwarderLambdaARN'
-          LOG_GROUP_NAMES: !Ref 'CloudWatchLogGroupsNames'
-          LOG_GROUP_PREFIX: !Ref 'CloudWatchLogGroupsPrefix'
-          LOG_GROUP_PATTERN: !Ref 'CloudWatchLogGroupsPattern'
+          AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"
+          LOG_GROUP_NAMES: !Ref "CloudWatchLogGroupsNames"
+          LOG_GROUP_PREFIX: !Ref "CloudWatchLogGroupsPrefix"
+          LOG_GROUP_PATTERN: !Ref "CloudWatchLogGroupsPattern"
   SubscriberInvoker:
     Type: AWS::CloudFormation::CustomResource
     DependsOn: SubscriberLambda

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -40,6 +40,7 @@ Resources:
               - logs:DeleteSubscriptionFilter
               - logs:PutSubscriptionFilter
               - logs:DescribeLogGroups
+              - logs:DescribeSubscriptionFilters
               - lambda:AddPermission
               - lambda:RemovePermission
             Effect: Allow

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -50,10 +50,10 @@ Resources:
         - !Ref "SubscriberRole"
   SubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
-      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -54,7 +54,7 @@ Resources:
   SubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}}-${LambdaFunctionName}"
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}-${LambdaFunctionName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -53,6 +53,10 @@ Resources:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Platform"
+          Value: "Axiom"
         - Key: "Role"
           Value: "AxiomCloudWatchSubscriber"
   SubscriberRole:
@@ -84,6 +88,15 @@ Resources:
         - Arn
       LoggingConfig:
         LogGroup: !Ref SubscriberLogGroup
+      Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Role"
+          Value: "AxiomCloudWatchSubscriber"
+        - Key: "Platform"
+          Value: "Axiom"
+        - Key: "ForwarderARN"
+          Value: !Ref "AxiomCloudWatchForwarderLambdaARN"
       Environment:
         Variables:
           AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -53,6 +53,7 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
+      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/subscriber.template.yaml
+++ b/cloudformation-stacks/subscriber.template.yaml
@@ -14,10 +14,6 @@ Metadata:
           - CloudWatchLogGroupsPattern
 
 Parameters:
-  LambdaFunctionName:
-    Type: String
-    Description: The name of the Subscriber Lambda function.
-    Default: "subscriber"
   AxiomCloudWatchForwarderLambdaARN:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to ship logs to Axiom.
@@ -54,7 +50,7 @@ Resources:
   SubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}-${LambdaFunctionName}"
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"
@@ -75,7 +71,7 @@ Resources:
   SubscriberLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${AWS::StackName}-${LambdaFunctionName}"
+      FunctionName: !Sub "${AWS::StackName}"
       Runtime: python3.9
       Handler: index.lambda_handler
       Timeout: 300

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -49,10 +49,10 @@ Resources:
         - !Ref "UnsubscriberRole"
   UnsubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
-      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -52,6 +52,7 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
+      DeletionPolicy: Delete
       Tags:
         - Key: "PartOf"
           Value: !Ref AWS::StackName

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -14,10 +14,6 @@ Metadata:
           - CloudWatchLogGroupsPattern
 
 Parameters:
-  LambdaFunctionName:
-    Type: String
-    Description: The name of the Unsubscriber Lambda function.
-    Default: "unsubscriber"
   AxiomCloudWatchForwarderLambdaARN:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to forward logs to Axiom.
@@ -54,8 +50,7 @@ Resources:
   UnsubscriberLogGroup:
     Type: "AWS::Logs::LogGroup"
     Properties:
-      LogGroupName: !Sub
-        - "/aws/axiom/${AWS::StackName}-${LambdaFunctionName}"
+      LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"
@@ -76,7 +71,7 @@ Resources:
   UnsubscriberLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${AWS::StackName}-unsubscriber"
+      FunctionName: !Sub "${AWS::StackName}"
       Runtime: python3.9
       Handler: index.lambda_handler
       Timeout: 300

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -53,8 +53,12 @@ Resources:
       LogGroupName: !Sub "/aws/axiom/${AWS::StackName}"
       RetentionInDays: 1
       Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
         - Key: "Role"
           Value: "AxiomCloudWatchUnsubscriber"
+        - Key: "Platform"
+          Value: "Axiom"
   UnsubscriberRole:
     Type: AWS::IAM::Role
     Properties:
@@ -84,6 +88,13 @@ Resources:
         - Arn
       LoggingConfig:
         LogGroup: !Ref UnsubscriberLogGroup
+      Tags:
+        - Key: "PartOf"
+          Value: !Ref AWS::StackName
+        - Key: "Role"
+          Value: "AxiomCloudWatchUnsubscriber"
+        - Key: "Platform"
+          Value: "Axiom"
       Environment:
         Variables:
           AXIOM_CLOUDWATCH_FORWARDER_LAMBDA_ARN: !Ref "AxiomCloudWatchForwarderLambdaARN"

--- a/cloudformation-stacks/unsubscriber.template.yaml
+++ b/cloudformation-stacks/unsubscriber.template.yaml
@@ -14,6 +14,10 @@ Metadata:
           - CloudWatchLogGroupsPattern
 
 Parameters:
+  LambdaFunctionName:
+    Type: String
+    Description: The name of the Unsubscriber Lambda function.
+    Default: "unsubscriber"
   AxiomCloudWatchForwarderLambdaARN:
     Type: String
     Description: The ARN of the Axiom CloudWatch Forwarder Lambda function used to forward logs to Axiom.
@@ -51,8 +55,7 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     Properties:
       LogGroupName: !Sub
-        - "/aws/axiom/forwarder/${LambdaFunctionName}"
-        - LambdaFunctionName: !Ref UnsubscriberLambda
+        - "/aws/axiom/${AWS::StackName}-${LambdaFunctionName}"
       RetentionInDays: 1
       Tags:
         - Key: "Role"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,82 @@
+# Use Axiom CloudWatch stacks with Terraform
+
+You can use Terraform to deploy Axiom CloudWatch stacks. This guide will show you how to deploy a CloudWatch stack using Terraform.
+
+
+## Deploying a Forwarder stack
+
+
+1. Fetch the stack URL from the main Readme.
+
+
+2. Create a new Terraform file and add the AWS provider:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.58.0"
+    }
+
+    axiom = {
+      source = "axiomhq/axiom"
+      version = "1.1.2"
+    }
+  }
+}
+```
+
+3. Configure Axiom provider and create a dataset and a token:
+
+```hcl
+provider "axiom" {
+  # Configuration options
+  base_url ="https://api.axiom.co"
+  api_token = "xaat-****-****"
+}
+
+resource "axiom_dataset" "lambda_forwarder" {
+  name = "cloudwatch-lambda"
+  description = "Lambda logs forwarded from AWS CloudWatch"
+}
+```
+
+4. Create a CloudFormation stack resource and add the stack URL as a template body:
+
+```hcl
+resource "aws_cloudformation_stack" "axiom_cloudwatch_lambda_forwarder" {
+  name = "axiom-cloudwatch-lambda-forwarder"
+
+  parameters = {
+    AxiomToken = "xaat-****"
+    AxiomDataset = axiom_dataset.lambda_forwarder.name
+    DataTags = ""
+  }
+
+  capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+
+  template_body = file("forwarder_stack_url")
+}
+```
+
+5. Now, a **Subscriber** is needed to tell the Forwarder which log groups to forward logs from. Create another stack resource to the Terraform file, this time it will have the **Subscriber** stack URL as the template body:
+
+```hcl
+resource "aws_cloudformation_stack" "axiom_cloudwatch_lambda_subscriber" {
+  name = "axiom-cloudwatch-lambda-subscriber"
+
+  parameters = {
+    AxiomCloudWatchForwarderLambdaARN = aws_cloudformation_stack.axiom_cloudwatch_lambda_forwarder.outputs.ForwarderLambdaARN
+    CloudWatchLogGroupsNames = ""
+
+    CloudWatchLogGroupsPrefix = "/aws/lambda/"
+
+    CloudWatchLogGroupsPattern = ""
+  }
+
+  capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+
+  template_body = file("subscriber-stack-url")
+}
+```

--- a/forwarder.py
+++ b/forwarder.py
@@ -162,7 +162,7 @@ def get_log_groups(nextToken=None):
 
 def lambda_handler(event: dict, context=None):
     # handle deletion of the stack
-    if event["RequestType"] == "Delete":
+    if "RequestType" in event and event["RequestType"] == "Delete":
         # remove all related subscription filters, unforutunately deleting the lambda will
         # not clear the subscription filters
         # We can do so by looping over log groups and deleting the subscription filters

--- a/subscriber.py
+++ b/subscriber.py
@@ -166,13 +166,7 @@ def lambda_handler(event: dict, context=None):
                 continue
     except Exception as e:
         responseData["success"] = "False"
-        if "ResponseURL" in event:
-            cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-        else:
-            raise e
+        cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
 
     responseData["success"] = "True"
-    if "ResponseURL" in event:
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-    else:
-        return "ok"
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)

--- a/subscriber.py
+++ b/subscriber.py
@@ -133,9 +133,7 @@ def lambda_handler(event: dict, context=None):
         try:
             remove_permission(statement_id, axiom_cloudwatch_forwarder_lambda_arn)
         except Exception as e:
-            logger.warning(
-                f"failed to remove permission for {cleaned_name}: {str(e)}"
-            )
+            logger.warning(f"failed to remove permission for {cleaned_name}: {str(e)}")
 
         try:
             add_permission(

--- a/subscriber.py
+++ b/subscriber.py
@@ -121,7 +121,9 @@ def create_subscription_filter(log_group_arn: str, lambda_arn: str):
 def lambda_handler(event: dict, context=None):
     # handle deletion of the stack
     if event["RequestType"] == "Delete":
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, event["PhysicalResourceId"])
+        cfnresponse.send(
+            event, context, cfnresponse.SUCCESS, {}, event["PhysicalResourceId"]
+        )
         return
 
     if (

--- a/subscriber.py
+++ b/subscriber.py
@@ -119,6 +119,11 @@ def create_subscription_filter(log_group_arn: str, lambda_arn: str):
 
 
 def lambda_handler(event: dict, context=None):
+    # handle deletion of the stack
+    if event["RequestType"] == "Delete":
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, event["PhysicalResourceId"])
+        return
+
     if (
         axiom_cloudwatch_forwarder_lambda_arn is None
         or axiom_cloudwatch_forwarder_lambda_arn == ""
@@ -148,10 +153,12 @@ def lambda_handler(event: dict, context=None):
 
         # if the log group already have a subscription filter, skip it
         try:
-            response = cloudwatch_logs_client.describe_subscription_filters(logGroupName=group['name'])
+            response = cloudwatch_logs_client.describe_subscription_filters(
+                logGroupName=group["name"]
+            )
             print(response)
             # TODO: improve the Subscription filters check
-            if len(response['subscriptionFilters']) > 0:
+            if len(response["subscriptionFilters"]) > 0:
                 logger.info(f"Subscription filter already exists for {cleaned_name}")
                 continue
         except Exception as e:

--- a/subscriber.py
+++ b/subscriber.py
@@ -129,7 +129,7 @@ def lambda_handler(event: dict, context=None):
         if group["name"].startswith("/aws/axiom/"):
             continue
         # create invoke permission for lambda
-        cleaned_name = '-'.join(group["name"].split("/")[3:])
+        cleaned_name = "-".join(group["name"].split("/")[3:])
         statement_id = f"invoke-permission-for_{cleaned_name}"
         # remove permission if exists
         try:

--- a/subscriber.py
+++ b/subscriber.py
@@ -29,14 +29,15 @@ def build_groups_list(
     pattern: Optional[str] = None,
     prefix: Optional[str] = None,
 ):
+    # ensure filter params have correct values
+    if not names:
+        names = None
+    if not pattern:
+        pattern = None
+    if not prefix:
+        prefix = None
     # filter out the log groups based on the names, pattern, and prefix provided in the environment variables
     groups = []
-    # ensure filter params have correct values
-    if pattern == "":
-        pattern = None
-    elif prefix == "":
-        prefix = None
-
     for g in all_groups:
         group = {"name": g["logGroupName"].strip(), "arn": g["arn"]}
         if names is None and pattern is None and prefix is None:

--- a/subscriber.py
+++ b/subscriber.py
@@ -146,6 +146,18 @@ def lambda_handler(event: dict, context=None):
         cleaned_name = "-".join(group["name"].split("/")[3:])
         statement_id = f"invoke-permission-for-{cleaned_name}"
 
+        # if the log group already have a subscription filter, skip it
+        try:
+            response = cloudwatch_logs_client.describe_subscription_filters(logGroupName=group['name'])
+            print(response)
+            # TODO: improve the Subscription filters check
+            if len(response['subscriptionFilters']) > 0:
+                logger.info(f"Subscription filter already exists for {cleaned_name}")
+                continue
+        except Exception as e:
+            logger.error(f"Error checking subscription filter for {cleaned_name}: {e}")
+            continue
+
         # remove subscription filter if exists
         try:
             delete_subscription_filter(group["name"])

--- a/unsubscriber.py
+++ b/unsubscriber.py
@@ -69,7 +69,12 @@ def delete_subscription_filter(log_group_name: str):
 
 def lambda_handler(event: dict, context=None):
     if axiom_cloudwatch_forwarder_lambda_arn is None:
-        raise Exception("AXIOM_CLOUDWATCH_LAMBDA_FORWARDER_ARN is not set")
+        responseData = {
+            "success": False,
+            "body": "AXIOM_CLOUDWATCH_LAMBDA_FORWARDER_ARN is not set",
+        }
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+        # raise Exception("AXIOM_CLOUDWATCH_LAMBDA_FORWARDER_ARN is not set")
 
     forwarder_lambda_group_name = (
         "/aws/lambda/" + axiom_cloudwatch_forwarder_lambda_arn.split(":")[-1]
@@ -96,13 +101,7 @@ def lambda_handler(event: dict, context=None):
     except Exception as e:
         responseData["success"] = "False"
         responseData["body"] = str(e)
-        if "ResponseURL" in event:
-            cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
-        else:
-            raise e
+        cfnresponse.send(event, context, cfnresponse.FAILED, responseData)
 
     responseData["success"] = "True"
-    if "ResponseURL" in event:
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-    else:
-        return "ok"
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)

--- a/unsubscriber.py
+++ b/unsubscriber.py
@@ -30,9 +30,11 @@ def build_groups_list(
     prefix: Optional[str] = None,
 ):
     # ensure filter params have correct values
-    if pattern == "":
+    if not names:
+        names = None
+    if not pattern:
         pattern = None
-    elif prefix == "":
+    if not prefix:
         prefix = None
     # filter out the log groups based on the names, pattern, and prefix provided in the environment variables
     groups = []


### PR DESCRIPTION
Using the `*` to allow Invoke permission for all the log groups, this causes a DX heckup as users won't be allowed to see a list of triggers inside the Forwarder lambda UI.

This PR alters the subscriber to create a permission statement for each log group. This would allow the Forwarder lambda to show lis t of triggers. 

