### PR TITLE
feat: add support for regional edge endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,10 @@ The forwarder supports edge-based regional ingestion for improved data locality.
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `AXIOM_URL` | The Axiom endpoint URL. If a path is provided (e.g., `http://localhost:3400/ingest`), it is used as-is. If no path is provided, `/v1/datasets/{dataset}/ingest` is appended for backwards compatibility. |
-| `AXIOM_EDGE_REGION` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). When set, data is sent to `https://{region}/v1/ingest/{dataset}`. |
+| `AXIOM_EDGE_URL` | Explicit edge URL (e.g., `https://custom-edge.example.com`). If a path is provided, the URL is used as-is. If no path is provided, `/v1/ingest/{dataset}` is appended. Takes precedence over `AXIOM_EDGE`. |
+| `AXIOM_EDGE` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). When set, data is sent to `https://{edge}/v1/ingest/{dataset}`. |
 
-**Priority:**
-1. `AXIOM_URL` with custom path → used as-is
-2. `AXIOM_EDGE_REGION` → `https://{region}/v1/ingest/{dataset}`
-3. `AXIOM_URL` without path → `{url}/v1/datasets/{dataset}/ingest` (backwards compatible)
+**Priority:** `AXIOM_EDGE_URL` > `AXIOM_EDGE` > `AXIOM_URL` (legacy)
 
 ### Examples
 
@@ -41,12 +38,15 @@ The forwarder supports edge-based regional ingestion for improved data locality.
 AXIOM_URL=https://api.axiom.co
 
 # Regional edge ingestion
-AXIOM_EDGE_REGION=eu-central-1.aws.edge.axiom.co
+AXIOM_EDGE=eu-central-1.aws.edge.axiom.co
 
-# Custom endpoint with path (used as-is)
-AXIOM_URL=http://localhost:3400/ingest
+# Explicit edge URL
+AXIOM_EDGE_URL=https://custom-edge.example.com
+
+# Explicit edge URL with custom path (used as-is)
+AXIOM_EDGE_URL=http://localhost:3400/ingest
 ```
 
 ### CloudFormation Parameters
 
-The forwarder stack accepts an optional `AxiomEdgeRegion` parameter for edge configuration. Existing deployments work unchanged—edge routing only activates when explicitly configured.
+The forwarder stack accepts optional `AxiomEdgeURL` and `AxiomEdge` parameters for edge configuration. Existing deployments work unchanged—edge routing only activates when explicitly configured.

--- a/README.md
+++ b/README.md
@@ -26,18 +26,27 @@ The forwarder supports edge-based regional ingestion for improved data locality.
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `AXIOM_EDGE_URL` | Explicit edge URL (e.g., `https://custom-edge.example.com`). Takes precedence over `AXIOM_EDGE_REGION`. |
-| `AXIOM_EDGE_REGION` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). |
+| `AXIOM_URL` | The Axiom endpoint URL. If a path is provided (e.g., `http://localhost:3400/ingest`), it is used as-is. If no path is provided, `/v1/datasets/{dataset}/ingest` is appended for backwards compatibility. |
+| `AXIOM_EDGE_REGION` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). When set, data is sent to `https://{region}/v1/ingest/{dataset}`. |
 
-**Priority:** `AXIOM_EDGE_URL` > `AXIOM_EDGE_REGION` > `AXIOM_URL` (default)
+**Priority:**
+1. `AXIOM_URL` with custom path → used as-is
+2. `AXIOM_EDGE_REGION` → `https://{region}/v1/ingest/{dataset}`
+3. `AXIOM_URL` without path → `{url}/v1/datasets/{dataset}/ingest` (backwards compatible)
 
-### Edge Endpoint
+### Examples
 
-When edge ingestion is configured, data is sent to:
-```
-https://{edge}/v1/ingest/{dataset}
+```bash
+# Traditional configuration (backwards compatible)
+AXIOM_URL=https://api.axiom.co
+
+# Regional edge ingestion
+AXIOM_EDGE_REGION=eu-central-1.aws.edge.axiom.co
+
+# Custom endpoint with path (used as-is)
+AXIOM_URL=http://localhost:3400/ingest
 ```
 
 ### CloudFormation Parameters
 
-The forwarder stack accepts optional `AxiomEdgeURL` and `AxiomEdgeRegion` parameters for edge configuration. Existing deployments work unchanged—edge routing only activates when explicitly configured.
+The forwarder stack accepts an optional `AxiomEdgeRegion` parameter for edge configuration. Existing deployments work unchanged—edge routing only activates when explicitly configured.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,27 @@ Axiom CloudWatch Forwarder is a set of easy-to-use AWS CloudFormation stacks des
 ## Documentation
 
 For more information about how to set up and use the Axiom CloudWatch Forwarder, see the [Axiom documentation](https://axiom.co/docs/send-data/cloudwatch).
+
+## Edge Ingestion
+
+The forwarder supports edge-based regional ingestion for improved data locality. When configured, ingest operations are routed to regional edge endpoints while maintaining full backwards compatibility.
+
+### Configuration
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `AXIOM_EDGE_URL` | Explicit edge URL (e.g., `https://custom-edge.example.com`). Takes precedence over `AXIOM_EDGE_REGION`. |
+| `AXIOM_EDGE_REGION` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). |
+
+**Priority:** `AXIOM_EDGE_URL` > `AXIOM_EDGE_REGION` > `AXIOM_URL` (default)
+
+### Edge Endpoint
+
+When edge ingestion is configured, data is sent to:
+```
+https://{edge}/v1/ingest/{dataset}
+```
+
+### CloudFormation Parameters
+
+The forwarder stack accepts optional `AxiomEdgeURL` and `AxiomEdgeRegion` parameters for edge configuration. Existing deployments work unchanged—edge routing only activates when explicitly configured.

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -11,6 +11,14 @@ Parameters:
     Default: "https://api.axiom.co"
     AllowedPattern: ".+" # required
     Description: The URL of the Axiom endpoint (without a trailing /). Defaults to "https://api.axiom.co".
+  AxiomEdgeURL:
+    Type: String
+    Default: ""
+    Description: Optional. Explicit edge URL for regional ingestion (e.g., https://custom-edge.example.com). Takes precedence over AxiomEdgeRegion.
+  AxiomEdgeRegion:
+    Type: String
+    Default: ""
+    Description: Optional. Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is ingested via the edge endpoint.
   AxiomDataset:
     Type: String
     Description: The name of the Axiom dataset to which events will be forwarded.
@@ -89,6 +97,8 @@ Resources:
           AXIOM_TOKEN: !Ref "AxiomToken"
           AXIOM_DATASET: !Ref "AxiomDataset"
           AXIOM_URL: !Ref "AxiomURL"
+          AXIOM_EDGE_URL: !Ref "AxiomEdgeURL"
+          AXIOM_EDGE_REGION: !Ref "AxiomEdgeRegion"
           DATA_TAGS: !Ref DataTags
   ForwarderLambdaPermission:
     Type: AWS::Lambda::Permission

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -10,11 +10,15 @@ Parameters:
     Type: String
     Default: "https://api.axiom.co"
     AllowedPattern: ".+" # required
-    Description: The URL of the Axiom endpoint. If a path is provided (e.g., http://localhost:3400/ingest), it is used as-is. If no path is provided, /v1/datasets/{dataset}/ingest is appended for backwards compatibility.
-  AxiomEdgeRegion:
+    Description: The URL of the Axiom endpoint (without a trailing /). Defaults to "https://api.axiom.co".
+  AxiomEdgeURL:
     Type: String
     Default: ""
-    Description: Optional. Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is sent to https://{region}/v1/ingest/{dataset}. Cannot be used together with a custom path in AxiomURL.
+    Description: Optional. Explicit edge URL for ingest operations (e.g., https://custom-edge.example.com). If a path is provided, the URL is used as-is. If no path is provided, /v1/ingest/{dataset} is appended. Takes precedence over AxiomEdge.
+  AxiomEdge:
+    Type: String
+    Default: ""
+    Description: Optional. Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is sent to https://{edge}/v1/ingest/{dataset}.
   AxiomDataset:
     Type: String
     Description: The name of the Axiom dataset to which events will be forwarded.
@@ -93,7 +97,8 @@ Resources:
           AXIOM_TOKEN: !Ref "AxiomToken"
           AXIOM_DATASET: !Ref "AxiomDataset"
           AXIOM_URL: !Ref "AxiomURL"
-          AXIOM_EDGE_REGION: !Ref "AxiomEdgeRegion"
+          AXIOM_EDGE_URL: !Ref "AxiomEdgeURL"
+          AXIOM_EDGE: !Ref "AxiomEdge"
           DATA_TAGS: !Ref DataTags
   ForwarderLambdaPermission:
     Type: AWS::Lambda::Permission

--- a/cloudformation-stacks/forwarder.template.yaml
+++ b/cloudformation-stacks/forwarder.template.yaml
@@ -10,15 +10,11 @@ Parameters:
     Type: String
     Default: "https://api.axiom.co"
     AllowedPattern: ".+" # required
-    Description: The URL of the Axiom endpoint (without a trailing /). Defaults to "https://api.axiom.co".
-  AxiomEdgeURL:
-    Type: String
-    Default: ""
-    Description: Optional. Explicit edge URL for regional ingestion (e.g., https://custom-edge.example.com). Takes precedence over AxiomEdgeRegion.
+    Description: The URL of the Axiom endpoint. If a path is provided (e.g., http://localhost:3400/ingest), it is used as-is. If no path is provided, /v1/datasets/{dataset}/ingest is appended for backwards compatibility.
   AxiomEdgeRegion:
     Type: String
     Default: ""
-    Description: Optional. Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is ingested via the edge endpoint.
+    Description: Optional. Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is sent to https://{region}/v1/ingest/{dataset}. Cannot be used together with a custom path in AxiomURL.
   AxiomDataset:
     Type: String
     Description: The name of the Axiom dataset to which events will be forwarded.
@@ -97,7 +93,6 @@ Resources:
           AXIOM_TOKEN: !Ref "AxiomToken"
           AXIOM_DATASET: !Ref "AxiomDataset"
           AXIOM_URL: !Ref "AxiomURL"
-          AXIOM_EDGE_URL: !Ref "AxiomEdgeURL"
           AXIOM_EDGE_REGION: !Ref "AxiomEdgeRegion"
           DATA_TAGS: !Ref DataTags
   ForwarderLambdaPermission:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ dependencies = [
 dev-dependencies = [
     "mypy>=1.11.2",
     "pre-commit>=3.8.0",
+    "pytest>=8.0.0",
     "ruff>=0.6.7",
 ]

--- a/src/test_forwarder.py
+++ b/src/test_forwarder.py
@@ -15,7 +15,8 @@ def _url_has_path(url: str) -> bool:
 
 def get_ingest_url_impl(
     axiom_url: str,
-    axiom_edge_region: str,
+    axiom_edge_url: str,
+    axiom_edge: str,
     dataset: str,
 ) -> str:
     """
@@ -23,15 +24,17 @@ def get_ingest_url_impl(
     This mirrors the logic in forwarder.py.
 
     Priority:
-    1. AXIOM_URL with custom path - Used as-is
-    2. AXIOM_URL without path - Appends /v1/datasets/{dataset}/ingest for backwards compat
-    3. AXIOM_EDGE_REGION - Regional edge domain, builds https://{region}/v1/ingest/{dataset}
-    4. Default cloud endpoint with legacy path
+    1. AXIOM_EDGE_URL with custom path - Used as-is
+    2. AXIOM_EDGE_URL without path - Appends /v1/ingest/{dataset}
+    3. AXIOM_EDGE - Regional edge domain, builds https://{edge}/v1/ingest/{dataset}
+    4. AXIOM_URL - Legacy path /v1/datasets/{dataset}/ingest
     """
-    if axiom_url and _url_has_path(axiom_url):
-        return axiom_url
-    elif axiom_edge_region:
-        return f"https://{axiom_edge_region}/v1/ingest/{dataset}"
+    if axiom_edge_url:
+        if _url_has_path(axiom_edge_url):
+            return axiom_edge_url
+        return f"{axiom_edge_url}/v1/ingest/{dataset}"
+    elif axiom_edge:
+        return f"https://{axiom_edge}/v1/ingest/{dataset}"
     else:
         return f"{axiom_url}/v1/datasets/{dataset}/ingest"
 
@@ -42,84 +45,82 @@ class TestUrlHasPath(unittest.TestCase):
     def test_url_without_path(self):
         self.assertFalse(_url_has_path("https://api.axiom.co"))
         self.assertFalse(_url_has_path("https://api.axiom.co/"))
-        self.assertFalse(_url_has_path("https://api.eu.axiom.co"))
-        self.assertFalse(_url_has_path("https://api.eu.axiom.co/"))
+        self.assertFalse(_url_has_path("https://custom-edge.example.com"))
+        self.assertFalse(_url_has_path("https://custom-edge.example.com/"))
 
     def test_url_with_path(self):
         self.assertTrue(_url_has_path("http://localhost:3400/ingest"))
         self.assertTrue(_url_has_path("https://custom.example.com/v1/ingest/dataset"))
-        self.assertTrue(_url_has_path("https://api.axiom.co/custom/path"))
+        self.assertTrue(_url_has_path("https://edge.example.com/custom/path"))
 
 
 class TestGetIngestUrl(unittest.TestCase):
-    """Tests for the get_ingest_url function and edge configuration."""
+    """Tests for the get_ingest_url function."""
 
-    def test_legacy_url_when_no_edge_configured(self):
-        """When no edge config is set, should use legacy AXIOM_URL path."""
+    def test_default_no_edge(self):
+        """No edge configured → legacy AXIOM_URL path."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_region="",
-            dataset="my-dataset",
+            axiom_edge_url="",
+            axiom_edge="",
+            dataset="foo",
         )
-        self.assertEqual(url, "https://api.axiom.co/v1/datasets/my-dataset/ingest")
+        self.assertEqual(url, "https://api.axiom.co/v1/datasets/foo/ingest")
 
-    def test_url_without_path_backwards_compat(self):
-        """URL without path should append legacy ingest path."""
-        url = get_ingest_url_impl(
-            axiom_url="https://api.eu.axiom.co",
-            axiom_edge_region="",
-            dataset="qoo",
-        )
-        self.assertEqual(url, "https://api.eu.axiom.co/v1/datasets/qoo/ingest")
-
-        # Also with trailing slash
-        url = get_ingest_url_impl(
-            axiom_url="https://api.eu.axiom.co/",
-            axiom_edge_region="",
-            dataset="qoo",
-        )
-        self.assertEqual(url, "https://api.eu.axiom.co//v1/datasets/qoo/ingest")
-
-    def test_url_with_custom_path_used_as_is(self):
-        """URL with custom path should be used as-is."""
-        url = get_ingest_url_impl(
-            axiom_url="http://localhost:3400/ingest",
-            axiom_edge_region="",
-            dataset="meh",
-        )
-        self.assertEqual(url, "http://localhost:3400/ingest")
-
-    def test_url_with_path_takes_precedence_over_region(self):
-        """URL with custom path takes precedence over edge region."""
-        url = get_ingest_url_impl(
-            axiom_url="http://localhost:3400/ingest",
-            axiom_edge_region="mumbai.axiom.co",
-            dataset="test",
-        )
-        self.assertEqual(url, "http://localhost:3400/ingest")
-
-    def test_edge_region_builds_correct_url(self):
-        """When AXIOM_EDGE_REGION is set (and no URL path), should build edge ingest URL."""
+    def test_edge_domain(self):
+        """AXIOM_EDGE set → builds https://{edge}/v1/ingest/{dataset}."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_region="eu-central-1.aws.edge.axiom.co",
+            axiom_edge_url="",
+            axiom_edge="eu-central-1.aws.edge.axiom.co",
             dataset="my-dataset",
         )
         self.assertEqual(
             url, "https://eu-central-1.aws.edge.axiom.co/v1/ingest/my-dataset"
         )
 
-    def test_region_domain_only(self):
-        """Region should be domain only, builds full URL."""
+    def test_edge_url_without_path(self):
+        """AXIOM_EDGE_URL without path → appends /v1/ingest/{dataset}."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_region="mumbai.axiom.co",
-            dataset="test-3",
+            axiom_edge_url="https://custom-edge.example.com",
+            axiom_edge="",
+            dataset="my-dataset",
         )
-        self.assertEqual(url, "https://mumbai.axiom.co/v1/ingest/test-3")
+        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/my-dataset")
 
-    def test_various_edge_regions(self):
-        """Test various edge region formats."""
+    def test_edge_url_with_custom_path(self):
+        """AXIOM_EDGE_URL with custom path → used as-is."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="http://localhost:3400/ingest",
+            axiom_edge="",
+            dataset="meh",
+        )
+        self.assertEqual(url, "http://localhost:3400/ingest")
+
+    def test_edge_url_takes_precedence_over_edge(self):
+        """AXIOM_EDGE_URL takes precedence over AXIOM_EDGE."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="https://custom-edge.example.com",
+            axiom_edge="mumbai.axiom.co",
+            dataset="test",
+        )
+        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/test")
+
+    def test_edge_url_with_path_takes_precedence_over_edge(self):
+        """AXIOM_EDGE_URL with path takes precedence over AXIOM_EDGE."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="http://localhost:3400/ingest",
+            axiom_edge="mumbai.axiom.co",
+            dataset="test",
+        )
+        self.assertEqual(url, "http://localhost:3400/ingest")
+
+    def test_various_edge_domains(self):
+        """Test various edge domain formats."""
         test_cases = [
             ("mumbai.axiom.co", "logs", "https://mumbai.axiom.co/v1/ingest/logs"),
             (
@@ -134,23 +135,25 @@ class TestGetIngestUrl(unittest.TestCase):
             ),
         ]
 
-        for region, dataset, expected in test_cases:
-            with self.subTest(region=region, dataset=dataset):
+        for edge, dataset, expected in test_cases:
+            with self.subTest(edge=edge, dataset=dataset):
                 url = get_ingest_url_impl(
                     axiom_url="https://api.axiom.co",
-                    axiom_edge_region=region,
+                    axiom_edge_url="",
+                    axiom_edge=edge,
                     dataset=dataset,
                 )
                 self.assertEqual(url, expected)
 
-    def test_default_no_config(self):
-        """No url path, no region → default cloud with legacy path."""
+    def test_custom_axiom_url_no_edge(self):
+        """Custom AXIOM_URL (self-hosted) with no edge → legacy path."""
         url = get_ingest_url_impl(
-            axiom_url="https://api.axiom.co",
-            axiom_edge_region="",
-            dataset="foo",
+            axiom_url="https://axiom.mycompany.com",
+            axiom_edge_url="",
+            axiom_edge="",
+            dataset="logs",
         )
-        self.assertEqual(url, "https://api.axiom.co/v1/datasets/foo/ingest")
+        self.assertEqual(url, "https://axiom.mycompany.com/v1/datasets/logs/ingest")
 
 
 if __name__ == "__main__":

--- a/src/test_forwarder.py
+++ b/src/test_forwarder.py
@@ -1,0 +1,117 @@
+"""Tests for edge URL configuration in forwarder.py"""
+
+import unittest
+
+
+def get_ingest_url_impl(
+    axiom_url: str,
+    axiom_edge_url: str,
+    axiom_edge_region: str,
+    dataset: str,
+) -> str:
+    """
+    Standalone implementation of get_ingest_url for testing.
+    This mirrors the logic in forwarder.py.
+    """
+    if axiom_edge_url:
+        return f"{axiom_edge_url}/v1/ingest/{dataset}"
+    elif axiom_edge_region:
+        return f"https://{axiom_edge_region}/v1/ingest/{dataset}"
+    else:
+        return f"{axiom_url}/v1/datasets/{dataset}/ingest"
+
+
+class TestGetIngestUrl(unittest.TestCase):
+    """Tests for the get_ingest_url function and edge configuration."""
+
+    def test_legacy_url_when_no_edge_configured(self):
+        """When no edge config is set, should use legacy AXIOM_URL path."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="",
+            axiom_edge_region="",
+            dataset="my-dataset",
+        )
+        self.assertEqual(url, "https://api.axiom.co/v1/datasets/my-dataset/ingest")
+
+    def test_edge_region_builds_correct_url(self):
+        """When AXIOM_EDGE_REGION is set, should build edge ingest URL."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="",
+            axiom_edge_region="eu-central-1.aws.edge.axiom.co",
+            dataset="my-dataset",
+        )
+        self.assertEqual(
+            url, "https://eu-central-1.aws.edge.axiom.co/v1/ingest/my-dataset"
+        )
+
+    def test_edge_url_builds_correct_url(self):
+        """When AXIOM_EDGE_URL is set, should use it directly."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="https://custom-edge.example.com",
+            axiom_edge_region="",
+            dataset="my-dataset",
+        )
+        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/my-dataset")
+
+    def test_edge_url_takes_precedence_over_region(self):
+        """AXIOM_EDGE_URL should take precedence over AXIOM_EDGE_REGION."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="https://custom-edge.example.com",
+            axiom_edge_region="eu-central-1.aws.edge.axiom.co",
+            dataset="my-dataset",
+        )
+        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/my-dataset")
+
+    def test_various_edge_regions(self):
+        """Test various edge region formats."""
+        test_cases = [
+            ("mumbai.axiom.co", "logs", "https://mumbai.axiom.co/v1/ingest/logs"),
+            (
+                "us-east-1.aws.edge.axiom.co",
+                "prod-logs",
+                "https://us-east-1.aws.edge.axiom.co/v1/ingest/prod-logs",
+            ),
+            (
+                "eu-west-1.edge.staging.axiom.co",
+                "test",
+                "https://eu-west-1.edge.staging.axiom.co/v1/ingest/test",
+            ),
+        ]
+
+        for region, dataset, expected in test_cases:
+            with self.subTest(region=region, dataset=dataset):
+                url = get_ingest_url_impl(
+                    axiom_url="https://api.axiom.co",
+                    axiom_edge_url="",
+                    axiom_edge_region=region,
+                    dataset=dataset,
+                )
+                self.assertEqual(url, expected)
+
+    def test_default_axiom_url(self):
+        """Test with default Axiom URL."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.axiom.co",
+            axiom_edge_url="",
+            axiom_edge_region="",
+            dataset="cloudwatch-logs",
+        )
+        self.assertEqual(url, "https://api.axiom.co/v1/datasets/cloudwatch-logs/ingest")
+
+    def test_custom_axiom_url(self):
+        """Test with custom Axiom URL (self-hosted)."""
+        url = get_ingest_url_impl(
+            axiom_url="https://axiom.mycompany.com",
+            axiom_edge_url="",
+            axiom_edge_region="",
+            dataset="logs",
+        )
+        self.assertEqual(url, "https://axiom.mycompany.com/v1/datasets/logs/ingest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test_forwarder.py
+++ b/src/test_forwarder.py
@@ -1,24 +1,54 @@
 """Tests for edge URL configuration in forwarder.py"""
 
 import unittest
+from urllib.parse import urlparse
+
+
+def _url_has_path(url: str) -> bool:
+    """Check if URL has a meaningful path (not empty or just '/')."""
+    try:
+        parsed = urlparse(url)
+        return parsed.path not in ("", "/")
+    except Exception:
+        return False
 
 
 def get_ingest_url_impl(
     axiom_url: str,
-    axiom_edge_url: str,
     axiom_edge_region: str,
     dataset: str,
 ) -> str:
     """
     Standalone implementation of get_ingest_url for testing.
     This mirrors the logic in forwarder.py.
+
+    Priority:
+    1. AXIOM_URL with custom path - Used as-is
+    2. AXIOM_URL without path - Appends /v1/datasets/{dataset}/ingest for backwards compat
+    3. AXIOM_EDGE_REGION - Regional edge domain, builds https://{region}/v1/ingest/{dataset}
+    4. Default cloud endpoint with legacy path
     """
-    if axiom_edge_url:
-        return f"{axiom_edge_url}/v1/ingest/{dataset}"
+    if axiom_url and _url_has_path(axiom_url):
+        return axiom_url
     elif axiom_edge_region:
         return f"https://{axiom_edge_region}/v1/ingest/{dataset}"
     else:
         return f"{axiom_url}/v1/datasets/{dataset}/ingest"
+
+
+class TestUrlHasPath(unittest.TestCase):
+    """Tests for the _url_has_path helper function."""
+
+    def test_url_without_path(self):
+        self.assertFalse(_url_has_path("https://api.axiom.co"))
+        self.assertFalse(_url_has_path("https://api.axiom.co/"))
+        self.assertFalse(_url_has_path("https://api.eu.axiom.co"))
+        self.assertFalse(_url_has_path("https://api.eu.axiom.co/"))
+
+    def test_url_with_path(self):
+        self.assertTrue(_url_has_path("http://localhost:3400/ingest"))
+        self.assertTrue(_url_has_path("https://custom.example.com/v1/ingest/dataset"))
+        self.assertTrue(_url_has_path("https://api.axiom.co/custom/path"))
 
 
 class TestGetIngestUrl(unittest.TestCase):
@@ -28,17 +58,50 @@ class TestGetIngestUrl(unittest.TestCase):
         """When no edge config is set, should use legacy AXIOM_URL path."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_url="",
             axiom_edge_region="",
             dataset="my-dataset",
         )
         self.assertEqual(url, "https://api.axiom.co/v1/datasets/my-dataset/ingest")
 
+    def test_url_without_path_backwards_compat(self):
+        """URL without path should append legacy ingest path."""
+        url = get_ingest_url_impl(
+            axiom_url="https://api.eu.axiom.co",
+            axiom_edge_region="",
+            dataset="qoo",
+        )
+        self.assertEqual(url, "https://api.eu.axiom.co/v1/datasets/qoo/ingest")
+
+        # Also with trailing slash
+        url = get_ingest_url_impl(
+            axiom_url="https://api.eu.axiom.co/",
+            axiom_edge_region="",
+            dataset="qoo",
+        )
+        self.assertEqual(url, "https://api.eu.axiom.co//v1/datasets/qoo/ingest")
+
+    def test_url_with_custom_path_used_as_is(self):
+        """URL with custom path should be used as-is."""
+        url = get_ingest_url_impl(
+            axiom_url="http://localhost:3400/ingest",
+            axiom_edge_region="",
+            dataset="meh",
+        )
+        self.assertEqual(url, "http://localhost:3400/ingest")
+
+    def test_url_with_path_takes_precedence_over_region(self):
+        """URL with custom path takes precedence over edge region."""
+        url = get_ingest_url_impl(
+            axiom_url="http://localhost:3400/ingest",
+            axiom_edge_region="mumbai.axiom.co",
+            dataset="test",
+        )
+        self.assertEqual(url, "http://localhost:3400/ingest")
+
     def test_edge_region_builds_correct_url(self):
-        """When AXIOM_EDGE_REGION is set, should build edge ingest URL."""
+        """When AXIOM_EDGE_REGION is set (and no URL path), should build edge ingest URL."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_url="",
             axiom_edge_region="eu-central-1.aws.edge.axiom.co",
             dataset="my-dataset",
         )
@@ -46,25 +109,14 @@ class TestGetIngestUrl(unittest.TestCase):
             url, "https://eu-central-1.aws.edge.axiom.co/v1/ingest/my-dataset"
         )
 
-    def test_edge_url_builds_correct_url(self):
-        """When AXIOM_EDGE_URL is set, should use it directly."""
+    def test_region_domain_only(self):
+        """Region should be domain only, builds full URL."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_url="https://custom-edge.example.com",
-            axiom_edge_region="",
-            dataset="my-dataset",
+            axiom_edge_region="mumbai.axiom.co",
+            dataset="test-3",
         )
-        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/my-dataset")
-
-    def test_edge_url_takes_precedence_over_region(self):
-        """AXIOM_EDGE_URL should take precedence over AXIOM_EDGE_REGION."""
-        url = get_ingest_url_impl(
-            axiom_url="https://api.axiom.co",
-            axiom_edge_url="https://custom-edge.example.com",
-            axiom_edge_region="eu-central-1.aws.edge.axiom.co",
-            dataset="my-dataset",
-        )
-        self.assertEqual(url, "https://custom-edge.example.com/v1/ingest/my-dataset")
+        self.assertEqual(url, "https://mumbai.axiom.co/v1/ingest/test-3")
 
     def test_various_edge_regions(self):
         """Test various edge region formats."""
@@ -86,31 +138,19 @@ class TestGetIngestUrl(unittest.TestCase):
             with self.subTest(region=region, dataset=dataset):
                 url = get_ingest_url_impl(
                     axiom_url="https://api.axiom.co",
-                    axiom_edge_url="",
                     axiom_edge_region=region,
                     dataset=dataset,
                 )
                 self.assertEqual(url, expected)
 
-    def test_default_axiom_url(self):
-        """Test with default Axiom URL."""
+    def test_default_no_config(self):
+        """No url path, no region → default cloud with legacy path."""
         url = get_ingest_url_impl(
             axiom_url="https://api.axiom.co",
-            axiom_edge_url="",
             axiom_edge_region="",
-            dataset="cloudwatch-logs",
+            dataset="foo",
         )
-        self.assertEqual(url, "https://api.axiom.co/v1/datasets/cloudwatch-logs/ingest")
-
-    def test_custom_axiom_url(self):
-        """Test with custom Axiom URL (self-hosted)."""
-        url = get_ingest_url_impl(
-            axiom_url="https://axiom.mycompany.com",
-            axiom_edge_url="",
-            axiom_edge_region="",
-            dataset="logs",
-        )
-        self.assertEqual(url, "https://axiom.mycompany.com/v1/datasets/logs/ingest")
+        self.assertEqual(url, "https://api.axiom.co/v1/datasets/foo/ingest")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add edge-based ingestion support for improved data locality. When configured, ingest operations are routed to regional edge endpoints while all other API operations continue using the main Axiom endpoint.

This aligns with the implementations in:
- [axiomhq/axiom-go#401](https://github.com/axiomhq/axiom-go/pull/401)
- [vectordotdev/vector#24037](https://github.com/vectordotdev/vector/pull/24037)

## Configuration

| Environment Variable | Description |
|---------------------|-------------|
| `AXIOM_EDGE_URL` | Explicit edge URL (e.g., `https://custom-edge.example.com`). If a path is provided, the URL is used as-is. If no path is provided, `/v1/ingest/{dataset}` is appended. Takes precedence over `AXIOM_EDGE`. |
| `AXIOM_EDGE` | Regional edge domain (e.g., `eu-central-1.aws.edge.axiom.co`). When set, data is sent to `https://{edge}/v1/ingest/{dataset}`. |

**Priority:** `AXIOM_EDGE_URL` > `AXIOM_EDGE` > `AXIOM_URL` (legacy)

## Backwards Compatibility

- Existing deployments work unchanged (no new required parameters)
- Edge routing only activates when explicitly configured
- `AXIOM_URL` remains purely the main API endpoint
- Legacy ingest path (`/v1/datasets/{dataset}/ingest`) preserved when no edge configured

## Changes

- `src/forwarder.py` — Added `AXIOM_EDGE_URL`/`AXIOM_EDGE` env vars, smart path detection, and `get_ingest_url()` helper
- `cloudformation-stacks/forwarder.template.yaml` — Added optional `AxiomEdgeURL` and `AxiomEdge` parameters
- `README.md` — Added Edge Ingestion documentation
- `src/test_forwarder.py` — Added tests for edge URL building logic
- `pyproject.toml` — Added pytest dev dependency